### PR TITLE
Include only parts of lodash used

### DIFF
--- a/lib/uptown.js
+++ b/lib/uptown.js
@@ -1,4 +1,8 @@
-var _ = require('lodash');
+var _create = require('lodash/create');
+var _extend = require('lodash/extend');
+var _forEach = require('lodash/forEach');
+var _has = require('lodash/has');
+var _isObject = require('lodash/isObject');
 
 // This function borrows very heavily from Backbone's extend function
 // See https://github.com/jashkenas/backbone/blob/938a8ff934fd4de4f0009f68d43f500f5920b490/backbone.js#L1821-L1852
@@ -7,25 +11,25 @@ exports.extend = function(protoProps, staticProps, gettersSetters) {
   var child;
 
   // Allow for specifying a constructor method for extend
-  if (protoProps && _.has(protoProps, 'constructor')) {
+  if (protoProps && _has(protoProps, 'constructor')) {
     child = protoProps.constructor;
   } else {
     child = function() { return parent.apply(this, arguments); };
   }
 
   // Inherit prototype from parent along with any given methods or properties
-  child.prototype = _.create(parent.prototype, protoProps);
+  child.prototype = _create(parent.prototype, protoProps);
 
   // Allow for defining getters and setters on new classes
-  if (gettersSetters && _.isObject(gettersSetters)) {
-    _.forEach(gettersSetters, function(value, key) {
+  if (gettersSetters && _isObject(gettersSetters)) {
+    _forEach(gettersSetters, function(value, key) {
       Object.defineProperty(child.prototype, key, value);
     });
   }
 
   // Add static methods and properties from the parent and from given static
   // properites (if provided);
-  _.extend(child, parent, staticProps);
+  _extend(child, parent, staticProps);
 
   return child;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uptown",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Simple ways to extend prototypes",
   "main": "lib/uptown.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:full && npm run build:min",
-    "build:full": "browserify -d -s uptown -x lodash -o dist/uptown.js lib/uptown.js",
-    "build:min": "browserify -d -s uptown lib/uptown.js | uglifyjs > dist/uptown.min.js",
+    "build:full": "browserify -d -s uptown -o dist/uptown.js lib/uptown.js",
+    "build:min": "cat dist/uptown.js | uglifyjs > dist/uptown.min.js",
     "test": "mocha --recursive"
   },
   "keywords": [


### PR DESCRIPTION
This has a positive impact on resultant dist sizes. We can now include lodash in all of the dist JS files. Before we decided only to include it in minified version because lodash was so large.

From master:

```
1.3M uptown.js (excludes lodash)
144K uptown.min.js
```

From this branch, which now includes lodash in all bundles, not just the minified one:

```
196K uptown.js (includes lodash)
40K  uptown.min.js
```